### PR TITLE
Fixes a misspelled 'response' variable

### DIFF
--- a/source/image-handler/lambda_function.py
+++ b/source/image-handler/lambda_function.py
@@ -213,7 +213,7 @@ def request_thumbor(original_request, session):
 
 def process_thumbor_responde(thumbor_response, vary):
      if thumbor_response.status_code != 200:
-         return response_formater(status_code=response.status_code)
+         return response_formater(status_code=thumbor_response.status_code)
      if vary:
          vary = thumbor_response.headers['vary']
      content_type = thumbor_response.headers['content-type']


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/serverless-image-handler/issues/33

*Description of changes:*

This is a minor change to process_thumbor_responde()
It changes the status code variable which is not correctly defined. I've seen python exceptions on cloudwatch related to this undefined variable. 

