### PR TITLE
Thumbor 6.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deployment/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-deployment/
+deployment/dist

--- a/.vimrc
+++ b/.vimrc
@@ -1,2 +1,0 @@
-nmap <silent> <leader>b :!clear && docker build -t amazonlinux:thumbor .<cr>
-nmap <silent> <leader>r :!clear && docker run -it --rm --name thumbor --volume $PWD:/app amazonlinux:thumbor /bin/bash<cr>

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,2 @@
+nmap <silent> <leader>b :!clear && docker build -t amazonlinux:thumbor .<cr>
+nmap <silent> <leader>r :!clear && docker run -it --rm --name thumbor --volume $PWD:/app amazonlinux:thumbor /bin/bash<cr>

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,16 @@ RUN yum install -y ImageMagick-devel
 # Other libraries
 RUN yum install -y pngcrush libjpeg* gifsicle
 
+# optipng
+RUN wget http://dl.fedoraproject.org/pub/epel/6/x86_64/Packages/o/optipng-0.7.6-6.el6.x86_64.rpm && \
+    yum localinstall optipng-0.7.6-6.el6.x86_64.rpm -y && rm optipng*rpm
+
+# pngquant
+RUN wget http://dl.fedoraproject.org/pub/epel/6/x86_64/Packages/l/libimagequant-2.5.2-5.el6.x86_64.rpm && \
+    yum localinstall libimagequant-2.5.2-5.el6.x86_64.rpm -y && rm libimagequant*rpm && \
+    wget http://dl.fedoraproject.org/pub/epel/6/x86_64/Packages/p/pngquant-2.5.2-5.el6.x86_64.rpm && \
+    yum localinstall pngquant-2.5.2-5.el6.x86_64.rpm -y && rm pngquant*rpm
+
 # pip
 RUN alias sudo='env PATH=$PATH' && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN sed -i 's/releasever=.*/releasever=2017.03/g' /etc/yum.conf
 # base requirements
 RUN yum install yum-utils zip -y && \
     yum-config-manager --enable epel && \
-    yum install git libpng-devel libcurl-devel gcc python27-devel libjpeg-devel -y
+    yum install wget git libpng-devel libcurl-devel gcc python27-devel libjpeg-devel -y
 
 # enable epel on Amazon Linux 2
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM amazonlinux:2017.03.1.20170812
 MAINTAINER Levi Wilson <levi@leviwilson.com>
 
+# lock yum to the same repository version
+RUN sed -i 's/releasever=.*/releasever=2017.03/g' /etc/yum.conf
+
+# base requirements
 RUN yum install yum-utils zip -y && \
     yum-config-manager --enable epel && \
-    yum update -y && \
-    yum install git libpng-devel libcurl-devel gcc python-devel libjpeg-devel -y
+    yum install git libpng-devel libcurl-devel gcc python27-devel libjpeg-devel -y
 
-RUN yum install python27 python27-setuptools.noarch -y
-
+# pip
 RUN alias sudo='env PATH=$PATH' && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && rm get-pip.py && \
@@ -15,6 +17,5 @@ RUN alias sudo='env PATH=$PATH' && \
     pip install --upgrade virtualenv
 
 # pycurl
-RUN yum install -y gcc-c++ make python27-devel openssl-devel
-
+RUN yum install -y openssl-devel
 ENV PYCURL_SSL_LIBRARY=openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM amazonlinux:2017.03.1.20170812
-MAINTAINER Levi Wilson <levi@leviwilson.com>
 
 # lock yum to the same repository version
 RUN sed -i 's/releasever=.*/releasever=2017.03/g' /etc/yum.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,10 @@ RUN alias sudo='env PATH=$PATH' && \
 # pycurl
 RUN yum install -y nss-devel
 ENV PYCURL_SSL_LIBRARY=nss
+
+RUN mkdir /lambda
+VOLUME /lambda
+WORKDIR /lambda/deployment
+
+ENTRYPOINT ["./build-s3-dist.sh"]
+CMD ["source-bucket-base-name"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM amazonlinux:2
+MAINTAINER Levi Wilson <levi@leviwilson.com>
+
+RUN yum install yum-utils zip -y && \
+    yum-config-manager --enable epel && \
+    yum update -y && \
+    yum install git libpng-devel libcurl-devel gcc python-devel libjpeg-devel -y
+
+RUN yum install python2 python2-pip.noarch python2-setuptools.noarch -y
+
+RUN alias sudo='env PATH=$PATH' && \
+    pip install --upgrade setuptools && \
+    pip install --upgrade virtualenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ RUN yum install python2 python2-pip.noarch python2-setuptools.noarch -y
 RUN alias sudo='env PATH=$PATH' && \
     pip install --upgrade setuptools && \
     pip install --upgrade virtualenv
+
+RUN yum install -y gcc-c++ make

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,6 @@ RUN alias sudo='env PATH=$PATH' && \
 # pycurl
 RUN yum install -y nss-devel
 ENV PYCURL_SSL_LIBRARY=nss
+
+# ImageMagick
+RUN yum install -y ImageMagick-devel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM amazonlinux:2017.03.1.20170812
 MAINTAINER Levi Wilson <levi@leviwilson.com>
 
 RUN yum install yum-utils zip -y && \
@@ -6,10 +6,15 @@ RUN yum install yum-utils zip -y && \
     yum update -y && \
     yum install git libpng-devel libcurl-devel gcc python-devel libjpeg-devel -y
 
-RUN yum install python2 python2-pip.noarch python2-setuptools.noarch -y
+RUN yum install python27 python27-setuptools.noarch -y
 
 RUN alias sudo='env PATH=$PATH' && \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py && rm get-pip.py && \
     pip install --upgrade setuptools && \
     pip install --upgrade virtualenv
 
-RUN yum install -y gcc-c++ make
+# pycurl
+RUN yum install -y gcc-c++ make python27-devel openssl-devel
+
+ENV PYCURL_SSL_LIBRARY=openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN yum install yum-utils zip -y && \
 # enable epel on Amazon Linux 2
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# ImageMagick
+RUN yum install -y ImageMagick-devel
+
 # pip
 RUN alias sudo='env PATH=$PATH' && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
@@ -22,6 +25,3 @@ RUN alias sudo='env PATH=$PATH' && \
 # pycurl
 RUN yum install -y nss-devel
 ENV PYCURL_SSL_LIBRARY=nss
-
-# ImageMagick
-RUN yum install -y ImageMagick-devel

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 # ImageMagick
 RUN yum install -y ImageMagick-devel
 
+# Other libraries
+RUN yum install -y pngcrush libjpeg* gifsicle
+
 # pip
 RUN alias sudo='env PATH=$PATH' && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN alias sudo='env PATH=$PATH' && \
     pip install --upgrade virtualenv
 
 # pycurl
-RUN yum install -y openssl-devel
-ENV PYCURL_SSL_LIBRARY=openssl
+RUN yum install -y nss-devel
+ENV PYCURL_SSL_LIBRARY=nss

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN yum install yum-utils zip -y && \
     yum-config-manager --enable epel && \
     yum install git libpng-devel libcurl-devel gcc python27-devel libjpeg-devel -y
 
+# enable epel on Amazon Linux 2
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
 # pip
 RUN alias sudo='env PATH=$PATH' && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \

--- a/README.md
+++ b/README.md
@@ -2,23 +2,34 @@
 A solution to dynamically handle images on the fly, utilizing Thumbor (thumbor.org).
 Published version, additional details and documentation are available here: https://aws.amazon.com/answers/web-applications/serverless-image-handler/
 
-## OS/Python Environment Setup
+## Docker Environment Setup
+In order to build the package locally, you'll need to build the docker image. In order to do so, run the following command:
+
 ```bash
-sudo yum-config-manager --enable epel
-sudo yum update -y
-sudo yum install git libpng-devel libcurl-devel gcc python-devel libjpeg-devel -y
-sudo pip install --upgrade pip
-alias sudo='sudo env PATH=$PATH'
-sudo  pip install --upgrade setuptools
-sudo pip install --upgrade virtualenv
+docker build -t serverless-image-handler .
 ```
 
+This will build a docker image that has the following properties:
+
+* pinned to the `amazonlinux` version that [Lambda runs on](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)
+* pinned yum repository to `releasever=2017.03`
+  * this is important when building `pycurl` so that the compiled version of libcurl does not differ from the runtime version on the Lambda AMI
+* has all of the base requirements installed
+  * libpng
+  * libjpeg
+  * pngcrush
+  * gifsicle
+  * optipng
+  * pngquant
+
 ## Building Lambda Package
+To build the Lambda package, use the `serverless-image-handler` image that was built earlier. The following command will build the deployment packages:
+
 ```bash
-cd deployment
-./build-s3-dist.sh source-bucket-base-name
+docker run -it --rm --volume $PWD:/lambda serverless-image-handler source-bucket-base-name
 ```
-source-bucket-base-name should be the base name for the S3 bucket location where the template will source the Lambda code from.
+
+`source-bucket-base-name` should be the base name for the S3 bucket location where the template will source the Lambda code from.
 The template will append '-[region_name]' to this value.
 For example: ./build-s3-dist.sh solutions
 The template will then expect the source code to be located in the solutions-[region_name] bucket
@@ -26,6 +37,13 @@ The template will then expect the source code to be located in the solutions-[re
 ## CF template and Lambda function
 Located in deployment/dist
 
+```
+deployment/dist/
+├── [2.0M]  serverless-image-handler-custom-resource.zip
+├── [6.4M]  serverless-image-handler-ui.zip
+├── [ 23K]  serverless-image-handler.template
+└── [ 48M]  serverless-image-handler.zip
+```
 
 ***
 

--- a/source/image-handler-custom-resource/setup.py
+++ b/source/image-handler-custom-resource/setup.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 setup(
     name='image_handler_custom_resource',

--- a/source/image-handler-custom-resource/setup.py
+++ b/source/image-handler-custom-resource/setup.py
@@ -1,10 +1,7 @@
 # coding: utf-8
 
 from setuptools import setup, find_packages
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
+from pip._internal.req import parse_requirements
 
 setup(
     name='image_handler_custom_resource',

--- a/source/image-handler/lambda_function.py
+++ b/source/image-handler/lambda_function.py
@@ -213,7 +213,7 @@ def request_thumbor(original_request, session):
 
 def process_thumbor_responde(thumbor_response, vary):
      if thumbor_response.status_code != 200:
-         return response_formater(status_code=response.status_code)
+         return response_formater(status_code=thumbor_response.status_code)
      if vary:
          vary = thumbor_response.headers['vary']
      content_type = thumbor_response.headers['content-type']

--- a/source/image-handler/setup.py
+++ b/source/image-handler/setup.py
@@ -26,10 +26,10 @@ setup(
             '': ['*.conf'],
     },
     install_requires=[
-        'botocore==1.3.7',
+        'botocore==1.8',
         'tornado_botocore==1.3.2',
         'requests_unixsocket>=0.1.5',
-        'thumbor>=6.4.2',
+        'thumbor>=6.5.2',
         'tc_aws==6.0.3',
         'opencv-python==3.2.0.6'
     ],

--- a/source/image-handler/setup.py
+++ b/source/image-handler/setup.py
@@ -26,8 +26,8 @@ setup(
             '': ['*.conf'],
     },
     install_requires=[
-        'botocore==1.11.6',
-        'tornado_botocore==1.4.0',
+        'botocore==1.8',
+        'tornado_botocore==1.3.2',
         'requests_unixsocket>=0.1.5',
         'thumbor>=6.5.2',
         'tc_aws==6.2.10',

--- a/source/image-handler/setup.py
+++ b/source/image-handler/setup.py
@@ -26,8 +26,8 @@ setup(
             '': ['*.conf'],
     },
     install_requires=[
-        'botocore==1.8',
-        'tornado_botocore==1.3.2',
+        'botocore==1.11.6',
+        'tornado_botocore==1.4.0',
         'requests_unixsocket>=0.1.5',
         'thumbor>=6.5.2',
         'tc_aws==6.2.10',

--- a/source/image-handler/setup.py
+++ b/source/image-handler/setup.py
@@ -30,7 +30,7 @@ setup(
         'tornado_botocore==1.3.2',
         'requests_unixsocket>=0.1.5',
         'thumbor>=6.5.2',
-        'tc_aws==6.0.3',
+        'tc_aws==6.2.10',
         'opencv-python==3.2.0.6'
     ],
     extras_require={

--- a/source/image-handler/setup.py
+++ b/source/image-handler/setup.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 tests_require = [
     'mock',
@@ -24,7 +27,7 @@ setup(
     },
     install_requires=[
         'botocore==1.3.7',
-        'tornado_botocore==1.0.2',
+        'tornado_botocore==1.3.2',
         'requests_unixsocket>=0.1.5',
         'thumbor>=6.4.2',
         'tc_aws==6.0.3',

--- a/source/image-handler/setup.py
+++ b/source/image-handler/setup.py
@@ -1,10 +1,7 @@
 # coding: utf-8
 
 from setuptools import setup, find_packages
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
+from pip._internal.req import parse_requirements
 
 tests_require = [
     'mock',


### PR DESCRIPTION
Originally I'd opened up https://github.com/awslabs/serverless-image-handler/issues/44 as I was having troubles being able to successfully build the lambda package from source. Some of the issues that I encountered are documented in there.

## Description
This pull request bumps the thumbor dependency from `6.4.2` ➡️ `6.5.2`. The version jump additionally fixes https://github.com/awslabs/serverless-image-handler/issues/43 in that it is now able to work with CCITT Fax4 TIFF images.

Additionally, in light of the issues I encountered with being able to successfully build the lambda function I dockerized the build so that it is repeatable.

In addition to the base dependencies that were originally in the README, I had to also pull in other dependencies into the docker image (pngcrust, gifsicle, pngquant, etc.) so that the lambda function wouldn't complain in the CloudWatch logs. Feedback welcome!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
