### PR TITLE
Add parameters for HTTP loader and safe URLs

### DIFF
--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -1,3 +1,4 @@
+---
 AWSTemplateFormatVersion: 2010-09-09
 
 Description: >-
@@ -49,6 +50,32 @@ Parameters:
       access to your API.
     Default: '*'
     Type: String
+  AllowUnsafeUrl:
+    Description: >-
+      Will this service allow unsafe URLs? If not, supply a security key.
+      See https://github.com/thumbor/thumbor/wiki/Security for details.
+    Default: 'Yes'
+    Type: String
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+  SecurityKey:
+    Description: ->
+      This is the key used to generate a hash-based message authentication code
+      and is required if unsafe URLs are not permitted.
+      See https://github.com/thumbor/thumbor/wiki/Security for details.
+      See also https://crypto.stackexchange.com/questions/35476/how-long-should-a-hmac-cryptographic-key-be
+      for recommendations around key content and length.
+    Default: 'unsafekey'
+    Type: String
+  EnableHttpLoader:
+    Description: >-
+      Will this service enable the HTTP image loader?
+    Default: 'No'
+    Type: String
+    AllowedValues:
+      - 'Yes'
+      - 'No'
   LambdaLogRetention:
     Description: Retain Lambda CloudWatch Logs by days.
     Type: Number
@@ -110,6 +137,9 @@ Metadata:
           - OriginS3BucketRegion
           - EnableCors
           - CorsOrig
+          - AllowUnsafeUrl
+          - SecurityKey
+          - EnableHttpLoader
           - LambdaLogRetention
       - Label:
           default: Image Handler UI Configuration
@@ -126,6 +156,12 @@ Metadata:
         default: Enable CORS?
       CorsOrig:
         default: CORS Origin
+      AllowUnsafeUrl:
+        default: Allow unsafe URLs?
+      SecurityKey:
+        default: Security Key (required if unsafe URLs are not allowed)
+      EnableHttpLoader:
+        default: Enable HTTP image loader
       LambdaLogRetention:
         default: Lambda Log Retention
       DeployUI:
@@ -359,6 +395,9 @@ Resources:
           REKOGNITION_REGION: us-east-1
           ENABLE_CORS: !Ref EnableCors
           CORS_ORIGIN: !Ref CorsOrig
+          ALLOW_UNSAFE_URL: !Ref AllowUnsafeUrl
+          SECURITY_KEY: !Ref SecurityKey
+          TC_AWS_ENABLE_HTTP_LOADER: !Ref EnableHttpLoader
           SEND_ANONYMOUS_DATA: !FindInMap
             - Send
             - AnonymousUsage
@@ -775,3 +814,9 @@ Outputs:
   CorsOrigin:
     Description: 'If enabled, allow CORS from this origin.'
     Value: !Ref CorsOrig
+  AllowUnsafeUrl:
+    Description: 'If enabled, allow Thumbor unsafe URL.'
+    Value: !Ref AllowUnsafeUrl
+  SecurityKey:
+    Description: 'Thumbor security key for safe URLs.'
+    Value: !Ref SecurityKey


### PR DESCRIPTION
This adds the same parameters as in https://github.com/awslabs/serverless-image-handler/pull/15 but for v3. I've deployed this successfully but there are a few issues even after I've verified the correct ENV vars get added to the lambda (see attached image below).

I think the changes in this PR are good to merge as it adds the correct env vars, but the below issues need to be addressed separately to get the expected functionally actually working.

1. The unsafe URLs still work even with `ALLOW_UNSAFE_URL="No"`. This was a problem even with ver 2 and this env var. Never been able to disable the unsafe url.
2. The signed URLs are broken. They worked correctly with version 2.2 and the template from https://github.com/awslabs/serverless-image-handler/pull/15 which created identical env vars. The error I'm getting now is new.
    ```
    [ERROR] 2018-09-27T20:52:26.207Z 3c728b24-c297-11e8-97e9-65b5097a44b9 generating signed url error: unsupported operand type(s) for +: 'NoneType' and 'str'
    ```
3. The above suggests to me that the ENV vars are either ignored or incorrectly named.

Could really use some help from others trying to get this working as documented.

![image](https://user-images.githubusercontent.com/721372/46174309-8988ef80-c25d-11e8-9cfb-f1220ee388fc.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
