### PR TITLE
vary should be set to 'Accept' in the response header 

### DIFF
--- a/source/image-handler/lambda_function.py
+++ b/source/image-handler/lambda_function.py
@@ -299,7 +299,7 @@ def process_thumbor_response(thumbor_response, vary):
      if thumbor_response.status_code != 200:
          return response_formater(status_code=thumbor_response.status_code)
      if vary:
-         vary = thumbor_response.headers['vary']
+         vary = 'Accept'
      content_type = thumbor_response.headers['content-type']
      body = gen_body(content_type, thumbor_response.content)
      # SO-SIH-173 - 08/20/2018 - Lambda payload limit

--- a/source/image-handler/lambda_function.py
+++ b/source/image-handler/lambda_function.py
@@ -295,7 +295,7 @@ def request_thumbor(original_request, session):
     vary, request_headers = auto_webp(original_request, request_headers)
     return session.get(unix_path + http_path, headers=request_headers), vary
 
-def process_thumbor_responde(thumbor_response, vary):
+def process_thumbor_response(thumbor_response, vary):
      if thumbor_response.status_code != 200:
          return response_formater(status_code=thumbor_response.status_code)
      if vary:
@@ -329,7 +329,7 @@ def call_thumbor(original_request):
     if thumbor_down:
         return thumbor_down
     thumbor_response, vary = request_thumbor(original_request, session)
-    return process_thumbor_responde(thumbor_response, vary)
+    return process_thumbor_response(thumbor_response, vary)
 
 def lambda_handler(event, context):
     """


### PR DESCRIPTION
When enabling webp we need to return vary: 'Accept'  header rather than take it from the request headers since it doesn't exist there and will throw an exception


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
