### PR TITLE
Add support for multiple CORS origins

### DIFF
--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -43,10 +43,10 @@ Parameters:
       - 'No'
   CorsOrig:
     Description: >-
-      This value will be returned by the API in the Access-Control-Allow-Origin
+      These value(s) will be returned by the API in the Access-Control-Allow-Origin
       header. A star (*) value will support any origin. We recommend specifying
       a specific origin (e.g. http://example.domain) to restrict cross-site
-      access to your API.
+      access to your API. Multiple origins can be provided when seperated by commas.
     Default: '*'
     Type: String
   LambdaLogRetention:
@@ -475,8 +475,9 @@ Resources:
             # SO-SIH-161 - 07/26/2018 - Improving CF hit rate
             # Allow CF to use same version for different Accept header values
             # https://github.com/awslabs/serverless-image-handler/issues/32
-            # Headers:
-            #   - Accept
+            Headers:
+            #  - Accept
+              - Origin
             QueryString: 'false'
             Cookies:
               Forward: none


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Altered CORS_ORIGIN to support multiple, comma separated origins to accept.

If disabled, no `Access-Control-Allow-Origin` header is passed into the response headers as happened previously.

If enabled, it checks if the content of `CORS_ORIGIN` is a single variable/asterisk or a comma separated list. If the variable contains a single origin, it simply passes the header (as before). If the the variable contains multiple valid origins, it looks for a match by comparing each entry in the list to the supplied `Origin` in the request headers. Sanitisation is performed by lowercasing both the `CORS_ORIGIN` list and `Origin` header.

If an exact match is found, the match is used as the value for the `Access-Control-Allow-Origin` header. If no match is found, the first `CORS_ORIGIN` element in the list is supplied as `Access-Control-Allow-Origin` as a failsafe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
