### PR TITLE
Region-specific IAM role name

### DIFF
--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -322,6 +322,8 @@ Resources:
         - ''
         - - !Ref 'AWS::StackName'
           - Role
+          - '-'
+          - !Ref 'AWS::Region'
   ImageHandlerFunction:
     Type: 'AWS::Lambda::Function'
     Properties:


### PR DESCRIPTION
Fixes "Creation failed. Reason: ImagerRole already exists" error.

"Naming an IAM resource can cause an unrecoverable error if you reuse the same template in multiple regions. To prevent this, we recommend using Fn::Join and AWS::Region to create a region-specific name."
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-rolename

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.