### PR TITLE
Honor outputFormat Parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # System Files
 **/.DS_Store
+deployment/{dist
+deployment/manifest-generator

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # System Files
 **/.DS_Store
-deployment/{dist
+deployment/dist
 deployment/manifest-generator

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ export VERSION=my-version # version number for the customized code
 ```
 _Note:_ You would have to create 2 buckets, one named 'my-bucket-name' and another regional bucket named 'my-bucket-name-<aws_region>'; aws_region is where you are testing the customized solution. Also, the assets  in bucket should be publicly accessible.
 
-```
 * Clone the github repo
 ```bash
 git clone https://github.com/awslabs/serverless-image-handler.git

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ _Note:_ In the above example, the solution template will expect the source code 
 https://s3.amazonaws.com/my-bucket-name/serverless-image-handler/my-version/serverless-image-handler.template
 ```
 
+### Docker
+If you have docker installed, you can build the distributable as well as run the unit tests with the following command from the root of the repository:
+
+```
+docker run --rm -it \
+           -v $PWD:/development \
+           -w /development \
+           amazonlinux:2018.03 ./package.sh $DIST_OUTPUT_BUCKET $TEMPLATE_OUTPUT_BUCKET $VERSION
+```
+
 Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+set -e
+
+# install prerequisites
+yum install -y gcc-c++ make which zip
+curl -sL https://rpm.nodesource.com/setup_8.x | bash -
+yum install -y nodejs
+
+cd deployment
+
+# tests
+./run-unit-tests.sh
+
+# build output package
+./build-s3-dist.sh $@

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -26,6 +26,11 @@ class ImageRequest {
             this.bucket = this.parseImageBucket(event, this.requestType);
             this.key = this.parseImageKey(event, this.requestType);
             this.edits = this.parseImageEdits(event, this.requestType);
+
+            if (this.requestType === 'Default') {
+              this.outputFormat = this.decodeRequest(event).outputFormat;
+            }
+
             this.originalImage = await this.getOriginalImage(this.bucket, this.key)
             return Promise.resolve(this);
         } catch (err) {

--- a/source/image-handler/test/test-image-request.js
+++ b/source/image-handler/test/test-image-request.js
@@ -23,7 +23,7 @@ describe('setup()', function() {
             the ImageRequest object with the proper values`, async function() {
             // Arrange
             const event = {
-                path : '/eyJidWNrZXQiOiJ2YWxpZEJ1Y2tldCIsImtleSI6InZhbGlkS2V5IiwiZWRpdHMiOnsiZ3JheXNjYWxlIjp0cnVlfX0='
+                path : '/eyJidWNrZXQiOiJ2YWxpZEJ1Y2tldCIsImtleSI6InZhbGlkS2V5IiwiZWRpdHMiOnsiZ3JheXNjYWxlIjp0cnVlfSwib3V0cHV0Rm9ybWF0IjoianBlZyJ9'
             }
             process.env = {
                 SOURCE_BUCKETS : "validBucket, validBucket2"
@@ -45,6 +45,7 @@ describe('setup()', function() {
                 bucket: 'validBucket',
                 key: 'validKey',
                 edits: { grayscale: true },
+                outputFormat: 'jpeg',
                 originalImage: Buffer.from('SampleImageContent\n')
             }
             // Assert


### PR DESCRIPTION
## Fixes
* Issue #116 

## Description
This PR fixes #116 by allowing the `outputFormat` to be specified in the JSON request when the `requestType: "Default"`.

This allows for the consumer to control what format the returned image is in according to what is allowable by [`Sharp#toFormat`](https://sharp.dimens.io/en/stable/api-output/#toformat)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
