### PR TITLE
Support serving images under s3 subdirectories, Fix to make /fit-in/ work; Fix for VipsJpeg: Invalid SOS error plus several other critical fixes.

### DIFF
--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -8,7 +8,7 @@
             "Type" : "String", 
             "AllowedValues" : [ "Yes", "No" ] 
         }, 
-        "CorsOrigin" : { 
+        "CorsOrigin" : {
             "Description" : "If you selected 'Yes' above, please specify an origin value here. A wildcard (*) value will support any origin. We recommend specifying an origin (i.e. https://example.domain) to restrict cross-site access to your API.", 
             "Default" : "*", 
             "Type" : "String" 
@@ -220,7 +220,7 @@
                     "S3Bucket" : { "Fn::Join": [ "-", [{ "Fn::FindInMap": [ "SourceCode", "General", "S3Bucket" ]}, { "Ref": "AWS::Region" }]]}, 
                     "S3Key" : "serverless-image-handler/%%VERSION%%/image-handler.zip" 
                 }, 
-                "Runtime": "nodejs8.10", 
+                "Runtime": "nodejs12.x",
                 "MemorySize": 1024,
                 "Timeout": 30,
                 "Environment" : { 
@@ -496,7 +496,7 @@
                     "S3Key": "serverless-image-handler/%%VERSION%%/custom-resource.zip" 
                 }, 
                 "Timeout": 30, 
-                "Runtime": "nodejs8.10", 
+                "Runtime": "nodejs12.x",
                 "Role": { "Fn::GetAtt": [ "CustomResourceRole", "Arn" ] }, 
                 "Handler": "index.handler"
             } 
@@ -675,4 +675,4 @@
             "Value" : { "Ref" : "LogRetentionPeriod" } 
         } 
     } 
-} 
+}

--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -42,7 +42,7 @@ class ImageHandler {
      * @param {Object} edits - The edits to be made to the original image.  
      */  
     async applyEdits(originalImage, edits) {  
-        const image = sharp(originalImage);  
+        const image = sharp(originalImage, { failOnError: false }).rotate();
         const keys = Object.keys(edits);  
         const values = Object.values(edits);  
         // Apply the image edits  

--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -24,10 +24,10 @@ class ImageHandler {
         const originalImage = request.originalImage; 
         const edits = request.edits; 
         if (edits !== undefined) { 
-            const modifiedImage = await this.applyEdits(originalImage, edits); 
+            const modifiedImage = await this.applyEdits(originalImage, edits);
             if (request.outputFormat !== undefined) {  
                 await modifiedImage.toFormat(request.outputFormat);  
-            }  
+            }
             const bufferImage = await modifiedImage.toBuffer();  
             return bufferImage.toString('base64'); 
         } else { 
@@ -41,7 +41,13 @@ class ImageHandler {
      * @param {Buffer} originalImage - The original image.  
      * @param {Object} edits - The edits to be made to the original image.  
      */  
-    async applyEdits(originalImage, edits) {  
+    async applyEdits(originalImage, edits) {
+        
+        if (edits.resize === undefined) {
+            edits.resize = {};
+            edits.resize.fit = "inside";
+        }
+
         const image = sharp(originalImage, { failOnError: false }).rotate();
         const keys = Object.keys(edits);  
         const values = Object.values(edits);  

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -14,7 +14,7 @@
 const ThumborMapping = require('./thumbor-mapping');
 
 class ImageRequest {
-    
+
     /**
      * Initializer function for creating a new image request, used by the image
      * handler to perform image modifications.
@@ -137,8 +137,11 @@ class ImageRequest {
             return decoded.key;
         } else if (requestType === "Thumbor" || requestType === "Custom") {
             // Parse the key from the end of the path
-            const key = (event["path"]).split("/");
-            return key[key.length - 1];
+            //const key = (event["path"]).split("/");
+            //return key[key.length - 1];
+
+            //Arpee: Support serving images under s3 subdirectories
+            return decodeURIComponent(event["path"].replace(/\/\d+x\d+/,'').substring(1));
         } else {
             // Return an error for all other conditions
             throw ({
@@ -160,8 +163,8 @@ class ImageRequest {
         const path = event["path"];
         // ----
         const matchDefault = new RegExp(/^(\/?)([0-9a-zA-Z+\/]{4})*(([0-9a-zA-Z+\/]{2}==)|([0-9a-zA-Z+\/]{3}=))?$/);
-        const matchThumbor = new RegExp(/^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?).*(.+jpg|.+png|.+webp|.+tiff|.+jpeg)$/);
-        const matchCustom = new RegExp(/(\/?)(.*)(jpg|png|webp|tiff|jpeg)/);
+        const matchThumbor = new RegExp(/^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?).*(.+jpg|.+png|.+webp|.+tiff|.+jpeg)$/i);
+        const matchCustom = new RegExp(/(\/?)(.*)(jpg|png|webp|tiff|jpeg)/i);
         const definedEnvironmentVariables = (
             (process.env.REWRITE_MATCH_PATTERN !== "") && 
             (process.env.REWRITE_SUBSTITUTION !== "") && 

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -141,7 +141,7 @@ class ImageRequest {
             //return key[key.length - 1];
 
             //Arpee: Support serving images under s3 subdirectories
-            return decodeURIComponent(event["path"].replace(/\d+x\d+|\/filters[:-][^/;]+|\/fit-in\/+|^\/+/g,'').replace(/^\//,''));
+            return decodeURIComponent(event["path"].replace(/\d+x\d+\/|filters[:-][^/;]+|\/fit-in\/+|^\/+/g,'').replace(/^\/+/,''));
         } else {
             // Return an error for all other conditions
             throw ({

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -136,11 +136,6 @@ class ImageRequest {
             const decoded = this.decodeRequest(event);
             return decoded.key;
         } else if (requestType === "Thumbor" || requestType === "Custom") {
-            // Parse the key from the end of the path
-            //const key = (event["path"]).split("/");
-            //return key[key.length - 1];
-
-            //Arpee: Support serving images under s3 subdirectories
             return decodeURIComponent(event["path"].replace(/\d+x\d+\/|filters[:-][^/;]+|\/fit-in\/+|^\/+/g,'').replace(/^\/+/,''));
         } else {
             // Return an error for all other conditions

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -141,7 +141,7 @@ class ImageRequest {
             //return key[key.length - 1];
 
             //Arpee: Support serving images under s3 subdirectories
-            return decodeURIComponent(event["path"].replace(/\d+x\d+|\/filters:[^/;]+|\/fit-in\/+|^\/+/g,'').substring(1));
+            return decodeURIComponent(event["path"].replace(/\d+x\d+|\/filters[:-][^/;]+|\/fit-in\/+|^\/+/g,'').substring(1));
         } else {
             // Return an error for all other conditions
             throw ({

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -141,7 +141,7 @@ class ImageRequest {
             //return key[key.length - 1];
 
             //Arpee: Support serving images under s3 subdirectories
-            return decodeURIComponent(event["path"].replace(/\/\d+x\d+/,'').substring(1));
+            return decodeURIComponent(event["path"].replace(/\d+x\d+|\/filters:[^/;]+|\/fit-in\/+|^\/+/g,'').substring(1));
         } else {
             // Return an error for all other conditions
             throw ({

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -141,7 +141,7 @@ class ImageRequest {
             //return key[key.length - 1];
 
             //Arpee: Support serving images under s3 subdirectories
-            return decodeURIComponent(event["path"].replace(/\d+x\d+|\/filters[:-][^/;]+|\/fit-in\/+|^\/+/g,'').substring(1));
+            return decodeURIComponent(event["path"].replace(/\d+x\d+|\/filters[:-][^/;]+|\/fit-in\/+|^\/+/g,'').replace(/^\//,''));
         } else {
             // Return an error for all other conditions
             throw ({

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "mocha": "^6.1.4",
-    "sharp": "^0.21.3",
+    "sharp": "^0.22.1",
     "sinon": "^7.3.2",
     "nyc": "^14.0.0"
   },

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "mocha": "^6.1.4",
-    "sharp": "^0.22.1",
+    "sharp": "^0.23.1",
     "sinon": "^7.3.2",
     "nyc": "^14.0.0"
   },

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "mocha": "^6.1.4",
-    "sharp": "^0.23.1",
+    "sharp": "^0.22.1",
     "sinon": "^7.3.2",
     "nyc": "^14.0.0"
   },

--- a/source/image-handler/test/test-thumbor-mapping.js
+++ b/source/image-handler/test/test-thumbor-mapping.js
@@ -30,12 +30,13 @@ describe('process()', function() {
             thumborMapping.process(event);
             // Assert
             const expectedResult = {
-                edits: { 
+                edits: {
+                    grayscale: true,
                     resize: {
                         width: 200,
-                        height: 300
-                    },
-                    grayscale: true
+                        height: 300,
+                        fit: 'inside'
+                    }
                 }
             };
             assert.deepEqual(thumborMapping.edits, expectedResult.edits);
@@ -628,7 +629,7 @@ describe('mapFilter()', function() {
             thumborMapping.mapFilter(edit, filetype);
             // Assert
             const expectedResult = {
-                edits: { 
+                edits: {
                     rotate: 0
                 }
             };

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -34,7 +34,7 @@ class ThumborMapping {
             const edit = edits[i];
             if (edit === ('fit-in')) {
                 this.edits.resize = {};
-                this.edits.resize.fit = "inside"
+                this.edits.resize.fit = 'inside'
                 this.sizingMethod = edit;
             } 
             else if (edit.includes('x')) {

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -37,10 +37,12 @@ class ThumborMapping {
             // Set only if the dimensions provided are valid
             if (isNaN(dims[0]) == false && isNaN(dims[1]) == false ){
                 this.edits.resize = {};
-                // Assign dimenions from the first match only to avoid parsing dimension from image file names
-                this.edits.resize.width = Number(dims[0]);
-                this.edits.resize.height = Number(dims[1]);
-
+                this.edits.resize.fit = 'inside'
+                if (this.edits.resize.width == undefined && this.edits.resize.height == undefined) {
+                    // Assign dimenions from the first match only to avoid parsing dimension from image file names
+                    this.edits.resize.width = Number(dims[0]);
+                    this.edits.resize.height = Number(dims[1]);
+                }
             }
         }
 

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -34,6 +34,7 @@ class ThumborMapping {
             const edit = edits[i];
             if (edit === ('fit-in')) {
                 this.edits.resize = {};
+                this.edits.resize.fit = "inside"
                 this.sizingMethod = edit;
             } 
             else if (edit.includes('x')) {

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -29,21 +29,31 @@ class ThumborMapping {
         this.path = event.path;
         const edits = this.path.split('/');
         const filetype = (this.path.split('.'))[(this.path.split('.')).length - 1];
+
+        //Process the Dimenions
+        const dimPath = this.path.match(/\d+x\d+/g);
+        if (dimPath) {
+            const dims = dimPath[0].split('x');
+            // Set only if the dimensions provided are valid
+            if (isNaN(dims[0]) == false && isNaN(dims[1]) == false ){
+                this.edits.resize = {};
+                // Assign dimenions from the first match only to avoid parsing dimension from image file names
+                this.edits.resize.width = Number(dims[0]);
+                this.edits.resize.height = Number(dims[1]);
+
+            }
+        }
+
         // Parse the image path
         for (let i = 0; i < edits.length; i++) {
             const edit = edits[i];
             if (edit === ('fit-in')) {
-                this.edits.resize = {};
+                if (this.edits.resize === undefined) {
+                    this.edits.resize = {};
+                }
                 this.edits.resize.fit = 'inside'
                 this.sizingMethod = edit;
-            } 
-            else if (edit.includes('x')) {
-                this.edits.resize = {};
-                const dims = edit.split('x');
-                this.edits.resize.width = Number(dims[0]);
-                this.edits.resize.height = Number(dims[1]);
-            } 
-            if (edit.includes('filters:')) {
+            } else if (edit.includes('filters:')) {
                 this.mapFilter(edit, filetype);
             }
         }

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -31,7 +31,7 @@ class ThumborMapping {
         const filetype = (this.path.split('.'))[(this.path.split('.')).length - 1];
 
         //Process the Dimenions
-        const dimPath = this.path.match(/\d+x\d+/g);
+        const dimPath = this.path.match(/[^\/]\d+x\d+/g);
         if (dimPath) {
             const dims = dimPath[0].split('x');
             // Set only if the dimensions provided are valid

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -30,7 +30,7 @@ class ThumborMapping {
         const edits = this.path.split('/');
         const filetype = (this.path.split('.'))[(this.path.split('.')).length - 1];
 
-        //Process the Dimenions
+        //Process the Dimensions
         const dimPath = this.path.match(/[^\/]\d+x\d+/g);
         if (dimPath) {
             const dims = dimPath[0].split('x');


### PR DESCRIPTION
This PR includes fixes for the following v4 issues:

- S3 subdirectories not working.
- /fit-in/ url directive not working.
- Exif orientation not honoured/followed.
- `VipsJpeg: Invalid SOS parameters for sequential JPEG` errors. This is observable with images taken with Samsung cameras, causing the api/cloudfront endpoint to output a blank json `{}` instead of the image.
- Wrong resizing if the path/filename contains an 'x' with surrounding digits (eg: /image8x8.jpg)

Sample paths in which this was tested on aside from the unit tests:

`/100x100/directory1/directory2/image.jpg` 
`/fit-in/100x100/directory1/directory2/image.jpg` 
`/fit-in/100x100/filters:someFilters/directory1/directory2/image.jpg` 
`/filters:someFilters/directory1/directory2/image.jpg` 
`/100x100/filters:someFilters/directory1/directory2/image_8x8x8x12.jpg`

You may start using this PR/Fork with this Exported Function zip: https://github.com/innovationlove/serverless-image-handler/releases/tag/4.0.1-ilove

Just replace the code that your Serverless Image Handler Function is using with the package above. USE AT YOUR OWN RISK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
