### PR TITLE
Allow regex in SOURCE_BUCKETS for environment variable

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -70,7 +70,7 @@ class ImageRequest {
             if (decoded.bucket !== undefined) {
                 // Check the provided bucket against the whitelist
                 const sourceBuckets = this.getAllowedSourceBuckets();
-                if (sourceBuckets.includes(decoded.bucket)) {
+                if (sourceBuckets.includes(decoded.bucket) || decoded.bucket.match(new RegExp('^' + sourceBuckets[0] + '$'))) {
                     return decoded.bucket;
                 } else {
                     throw ({


### PR DESCRIPTION
*Issue #, if available:*
#141

*Description of changes:*
This allow us to support regex in SOURCE_BUCKETS for the environment variable so that it matches a regex of bucket instead of CSV buckets.

Environment variable has limited string limit and doesn't allow us to enter a long list of buckets. (Imagine 50+ devs and each has their own bucket). Using regex won't have this character limit problem and is better for scaling.

I created a PR to demonstrate the idea of using regex in the field. It defaults to use `sourceBuckets[0]`. Improvement and feedback are welcome. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
