### PR TITLE
Fix build script on other platforms

### DIFF
--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -24,6 +24,6 @@
     "build:init": "rm -rf package-lock.json && rm -rf dist && rm -rf node_modules",
     "build:zip": "zip -rq image-handler.zip . -x template.yml",
     "build:dist": "mkdir dist && mv image-handler.zip dist/",
-    "build": "npm run build:init && npm install --production && npm run build:zip && npm run build:dist"
+    "build": "npm run build:init && npm install --arch=x64 --platform=linux --production && npm run build:zip && npm run build:dist"
   }
 }


### PR DESCRIPTION
*Description of changes:*
By updating the `npm install` section of the build script to force the linux binaries for the AMI, the solution can then also be built/deployed from a mac.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
