### PR TITLE
Add Cache-Control response header

### DIFF
--- a/source/image-handler/index.js
+++ b/source/image-handler/index.js
@@ -52,7 +52,8 @@ const getResponseHeaders = (isErr) => {
         "Access-Control-Allow-Methods": "GET",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
         "Access-Control-Allow-Credentials": true,
-        "Content-Type": "image"
+        "Content-Type": "image",
+        "Cache-Control": "max-age=31536000,public"
     }
     if (corsEnabled) {
         headers["Access-Control-Allow-Origin"] = process.env.CORS_ORIGIN;


### PR DESCRIPTION
The Thumbor version used to have this client side caching, would be nice to have it again.

Relates to #107

*Description of changes:*

Adding the cache-control header to the response like it used to be before v4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
