### PR TITLE
Custom headers

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -26,7 +26,8 @@ class ImageRequest {
             this.bucket = this.parseImageBucket(event, this.requestType);
             this.key = this.parseImageKey(event, this.requestType);
             this.edits = this.parseImageEdits(event, this.requestType);
-            this.originalImage = await this.getOriginalImage(this.bucket, this.key)
+            this.originalImage = await this.getOriginalImage(this.bucket, this.key);
+            this.headers = this.parseImageHeaders(event, this.requestType);
             return Promise.resolve(this);
         } catch (err) {
             return Promise.reject(err);
@@ -122,6 +123,22 @@ class ImageRequest {
                 message: 'The edits you provided could not be parsed. Please check the syntax of your request and refer to the documentation for additional guidance.'
             });
         }
+    }
+
+    /**
+     * Parses the headers to be sent with the response
+     * @param {String} event - Lambda request body.
+     * @param {String} requestType - Image handler request type.
+     */
+    parseImageHeaders(event, requestType) {
+        if (requestType === "Default") {
+            const decoded = this.decodeRequest(event);
+            if (decoded.headers !== undefined) {
+                return decoded.headers;
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/source/image-handler/index.js
+++ b/source/image-handler/index.js
@@ -22,9 +22,18 @@ exports.handler = async (event) => {
         const request = await imageRequest.setup(event);
         console.log(request);
         const processedRequest = await imageHandler.process(request);
+        const headers = getResponseHeaders();
+
+        if (request.headers) {
+            // Apply the custom headers overwriting any that may need overwriting
+            for (let i = 0; i < request.headers.length; i++) {
+                headers[request.headers[i].key] = request.headers[i].value;
+            }
+        }
+
         const response = {
             "statusCode": 200,
-            "headers" : getResponseHeaders(),
+            "headers" : headers,
             "body": processedRequest,
             "isBase64Encoded": true
         }
@@ -53,7 +62,8 @@ const getResponseHeaders = (isErr) => {
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
         "Access-Control-Allow-Credentials": true,
         "Content-Type": "image"
-    }
+    };
+
     if (corsEnabled) {
         headers["Access-Control-Allow-Origin"] = process.env.CORS_ORIGIN;
     }

--- a/source/image-handler/test/test-image-request.js
+++ b/source/image-handler/test/test-image-request.js
@@ -45,6 +45,7 @@ describe('setup()', function() {
                 bucket: 'validBucket',
                 key: 'validKey',
                 edits: { grayscale: true },
+                headers: [],
                 originalImage: Buffer.from('SampleImageContent\n')
             }
             // Assert
@@ -78,6 +79,7 @@ describe('setup()', function() {
                 bucket: 'allowedBucket001',
                 key: 'test-image-001.jpg',
                 edits: { grayscale: true },
+                headers: [],
                 originalImage: Buffer.from('SampleImageContent\n')
             }
             // Assert
@@ -116,6 +118,7 @@ describe('setup()', function() {
                     grayscale: true,
                     rotate: 90
                 },
+                headers: [],
                 originalImage: Buffer.from('SampleImageContent\n')
             }
             // Assert
@@ -645,3 +648,27 @@ describe('getAllowedSourceBuckets()', function() {
         });
     });
 })
+
+// ----------------------------------------------------------------------------
+// parseImageHeaders()
+// ----------------------------------------------------------------------------
+describe('parseImageHeaders()', function() {
+    describe('001/defaultCustomHeaders', function () {
+        it(`Should pass if the proper result is returned for a sample base64-
+            encoded image request`, function () {
+            // Arrange
+            const event = {
+                path: '/eyJoZWFkZXJzIjpbeyJrZXkiOiAiQ2FjaGUtQ29udHJvbCIsICJ2YWx1ZSI6ICJtYXgtYWdlPTMxNTM2MDAwLHB1YmxpYyJ9XX0='
+            }
+            // Act
+            const imageRequest = new ImageRequest();
+            const result = imageRequest.parseImageHeaders(event, 'Default');
+            // Assert
+            const expectedResult = [{
+                key: "Cache-Control",
+                value: 'max-age=31536000,public'
+            }]
+            assert.deepEqual(result, expectedResult);
+        });
+    });
+});


### PR DESCRIPTION
I'm trying to use the serverless image handler in our work environment but it doesn't seem to provide any cache mechanism. 

The solution is either pass along the Cache headers from S3 (we didn't set any when initially uploading the files). We could update the S3 meta data, or we could pass in the headers we want into the base64 string. This allows for much more customisation. Cache Control, Content Type headers. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
