### PR TITLE
fixed a bug where base64 encoding containing slash will fail

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -240,9 +240,8 @@ class ImageRequest {
     decodeRequest(event) {
         const path = event["path"];
         if (path !== undefined) {
-            const splitPath = path.split("/");
-            const encoded = splitPath[splitPath.length - 1];
-            const toBuffer = Buffer.from(encoded, 'base64');
+            const strippedPath = path.charAt(0) === '/' ? path.substr(1, path.length) : path;
+            const toBuffer = Buffer.from(strippedPath, 'base64');
             try {
                 // To support European characters, 'ascii' was removed.
                 return JSON.parse(toBuffer.toString());

--- a/source/image-handler/test/test-image-request.js
+++ b/source/image-handler/test/test-image-request.js
@@ -161,6 +161,20 @@ describe('setup()', function() {
             })
         });
     });
+    describe('005/encodingWithSlashRequest', function () {
+        it(`should read image requests with base64 encoding having slash`, function () {
+            const event = {
+                path : 'eyJidWNrZXQiOiJlbGFzdGljYmVhbnN0YWxrLXVzLWVhc3QtMi0wNjY3ODQ4ODU1MTgiLCJrZXkiOiJlbnYtcHJvZC9nY2MvbGFuZGluZ3BhZ2UvMV81N19TbGltTl9MaWZ0LUNvcnNldC1Gb3ItTWVuLVNOQVAvYXR0YWNobWVudHMvZmZjMWYxNjAtYmQzOC00MWU4LThiYWQtZTNhMTljYzYxZGQzX1/Ys9mE2YrZhSDZhNmK2YHYqiAoMikuanBnIiwiZWRpdHMiOnsicmVzaXplIjp7IndpZHRoIjo0ODAsImZpdCI6ImNvdmVyIn19fQ=='
+            }
+            // Act
+            const imageRequest = new ImageRequest();
+            const result = imageRequest.parseImageKey(event, 'Default');
+            // Assert
+            const expectedResult = 'env-prod/gcc/landingpage/1_57_SlimN_Lift-Corset-For-Men-SNAP/attachments/ffc1f160-bd38-41e8-8bad-e3a19cc61dd3__سليم ليفت (2).jpg';
+            assert.deepEqual(result, expectedResult);
+
+        })
+    });
 });
 // ----------------------------------------------------------------------------
 // getOriginalImage()


### PR DESCRIPTION
*Description of changes:*

I encountered a bug where base64 encoding for some requests might contain a slash, the decoding function splits on slashes which is buggy.




> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
