### PR TITLE
fix: properly evaluate process.env.AUTO_WEBP

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -287,7 +287,7 @@ class ImageRequest {
     * @param {Object} event - The request body.
     */
     getOutputFormat(event) {
-        const autoWebP = process.env.AUTO_WEBP;
+        const autoWebP = (process.env.AUTO_WEBP === "Yes");
         if (autoWebP && event.headers.Accept && event.headers.Accept.includes('image/webp')) {
             return 'webp';
         } else if (this.requestType === 'Default') {

--- a/source/image-handler/test/test-image-request.js
+++ b/source/image-handler/test/test-image-request.js
@@ -689,7 +689,7 @@ describe('getOutputFormat()', function () {
         it(`Should pass if it returns "webp" for an accepts header which includes webp`, function () {
             // Arrange
             process.env = {
-                AUTO_WEBP: true
+                AUTO_WEBP: "Yes"
             };
             const event = {
                 headers: {
@@ -707,7 +707,7 @@ describe('getOutputFormat()', function () {
         it(`Should pass if it returns null for an accepts header which does not include webp`, function () {
             // Arrange
             process.env = {
-                AUTO_WEBP: true
+                AUTO_WEBP: "Yes"
             };
             const event = {
                 headers: {
@@ -725,7 +725,7 @@ describe('getOutputFormat()', function () {
         it(`Should pass if it returns null when AUTO_WEBP is disabled with accepts header including webp`, function () {
             // Arrange
             process.env = {
-                AUTO_WEBP: false
+                AUTO_WEBP: "No"
             };
             const event = {
                 headers: {


### PR DESCRIPTION
*Description of changes:*
process.env.AUTO_WEBP isn't properly evaluated. CloudFormation file sets this ENV to either "Yes" or "No", but the code only checks if the ENV variable is present or not.

Change was introduced with the bug present in https://github.com/awslabs/serverless-image-handler/pull/152

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
