### PR TITLE
Enabling ALB Support

### DIFF
--- a/source/image-handler/index.js
+++ b/source/image-handler/index.js
@@ -18,13 +18,12 @@ exports.handler = async (event) => {
     console.log(event);
     const imageRequest = new ImageRequest();
     const imageHandler = new ImageHandler();
+    const isALB = event.requestContext && event.requestContext.hasOwnProperty("elb");
     try {
         const request = await imageRequest.setup(event);
-        const isALB = event.requestContext && event.requestContext.hasOwnProperty("elb");
         console.log(request);
         const processedRequest = await imageHandler.process(request);
-
-        const headers = getResponseHeaders(false, true);
+        const headers = getResponseHeaders(false, isALB);
         headers["Content-Type"] = request.ContentType;
         headers["Expires"] = request.Expires;
         headers["Last-Modified"] = request.LastModified;

--- a/source/image-handler/index.js
+++ b/source/image-handler/index.js
@@ -20,27 +20,27 @@ exports.handler = async (event) => {
     const imageHandler = new ImageHandler();
     try {
         const request = await imageRequest.setup(event);
+        const isALB = event.requestContext && event.requestContext.hasOwnProperty("elb");
         console.log(request);
         const processedRequest = await imageHandler.process(request);
 
-        const headers = getResponseHeaders();
+        const headers = getResponseHeaders(false, true);
         headers["Content-Type"] = request.ContentType;
         headers["Expires"] = request.Expires;
         headers["Last-Modified"] = request.LastModified;
         headers["Cache-Control"] = request.CacheControl;
-
         return {
             "statusCode": 200,
-            "headers" : headers,
+            "isBase64Encoded": true,
+            "headers": headers,
             "body": processedRequest,
-            "isBase64Encoded": true
-        };
+        }
     } catch (err) {
         console.log(err);
 
         return {
             "statusCode": err.status,
-            "headers" : getResponseHeaders(true),
+            "headers": getResponseHeaders(true, isALB),
             "body": JSON.stringify(err),
             "isBase64Encoded": false
         };
@@ -52,12 +52,14 @@ exports.handler = async (event) => {
  * or error condition.
  * @param {boolean} isErr - has an error been thrown?
  */
-const getResponseHeaders = (isErr) => {
+const getResponseHeaders = (isErr = false, isALB = false) => {
     const corsEnabled = (process.env.CORS_ENABLED === "Yes");
-    const headers = {
+    let headers = {
         "Access-Control-Allow-Methods": "GET",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        "Access-Control-Allow-Credentials": true
+    }
+    if (!isALB) {
+        headers["Access-Control-Allow-Credentials"] = true;
     }
     if (corsEnabled) {
         headers["Access-Control-Allow-Origin"] = process.env.CORS_ORIGIN;

--- a/source/image-handler/index.js
+++ b/source/image-handler/index.js
@@ -54,7 +54,7 @@ exports.handler = async (event) => {
  */
 const getResponseHeaders = (isErr = false, isALB = false) => {
     const corsEnabled = (process.env.CORS_ENABLED === "Yes");
-    let headers = {
+    const headers = {
         "Access-Control-Allow-Methods": "GET",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
     }

--- a/source/image-handler/index.js
+++ b/source/image-handler/index.js
@@ -40,9 +40,9 @@ exports.handler = async (event) => {
 
         return {
             "statusCode": err.status,
+            "isBase64Encoded": false,
             "headers": getResponseHeaders(true, isALB),
             "body": JSON.stringify(err),
-            "isBase64Encoded": false
         };
     }
 }


### PR DESCRIPTION

*Description of changes:*
This is a non breaking change, already tested and working in a production environment.

The ALB lambda integration is not well documented..

I Had to remove the  `Access-Control-Allow-Credentials` header when the request is coming from an ALB because  it was returning 502 when I tried with that header.

Also i found out(via test and errors) that the order of the returned object does matter as `isBase64Encoded` *must* be before the body, if it is not.

This should save the user the $3.5 per 1M if he does not need more features from APIGW, and it does also works with Cloudfront.

With this PR it will continue to work with APIGW without changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
