### PR TITLE
Add support for signed urls

### DIFF
--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -36,6 +36,11 @@
             "Default" : "No",
             "Type" : "String",
             "AllowedValues" : [ "Yes", "No" ]
+        },
+        "SignatureKey" : {
+            "Description" : "If you would like to use signed URLs, please specify a secret signature key here. Signature key will be used to validate base64 payloads.",
+            "Default" : "",
+            "Type" : "String"
         }
     },
     "Metadata": {
@@ -390,6 +395,9 @@
                         },
                         "SOURCE_BUCKETS" : {
                             "Ref" : "SourceBuckets"
+                        },
+                        "SIGNATURE_KEY": {
+                            "Ref" : "SignatureKey"
                         },
                         "REWRITE_MATCH_PATTERN" : "",
                         "REWRITE_SUBSTITUTION" : ""
@@ -846,6 +854,10 @@
             "Condition" : "EnableCorsCondition",
             "Description" : "Origin value returned in the Access-Control-Allow-Origin header of image handler API responses.",
             "Value" : { "Ref" : "CorsOrigin" }
+        },
+        "SignatureKey" : {
+            "Description" : "Key used to sign URLs.",
+            "Value" : { "Ref" : "SignatureKey" }
         },
         "LogRetentionPeriod" : {
             "Description" : "Number of days for event logs from Lambda to be retained in CloudWatch.",

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -8,9 +8,10 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "sharp": "^0.23.4",
+    "buffer-equal-constant-time": "^1.0.1",
     "color": "3.1.2",
-    "color-name": "1.1.4"
+    "color-name": "1.1.4",
+    "sharp": "^0.23.4"
   },
   "devDependencies": {
     "aws-sdk": "^2.437.0",


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/serverless-image-handler/issues/221

*Description of changes:*

Adds support for HMAC-signed urls to prevent tampering with base64-encoded params. 

URLs should be in the following format:

```
https://<cf-id>.cloudfront.net/<base64-path>--<signature>
```

Signatures are verified only if `SIGNATURE_KEY` env var is provided. 

How to generate a signature:

~~~ javascript
const crypto = require('crypto');
const key = "mySecretKey";

const imageRequest = JSON.stringify({
    bucket: "my-bucket",
    key: "image.png",
    edits: {
        grayscale: true
    }
});

const payload = Buffer.from(imageRequest).toString('base64');
const signature = crypto.createHmac('sha1', key).update(payload).digest('hex')

console.log(signature);
~~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
