### PR TITLE
Remove --recursive from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ chmod +x ./build-s3-dist.sh
 
 Deploy the distributable to the Amazon S3 bucket in your account:
 ```bash
-aws s3 sync ./regional-s3-assets/ s3://$DIST_OUTPUT_BUCKET-$REGION/$SOLUTION_NAME/$VERSION/ --recursive --acl bucket-owner-full-control
-aws s3 sync ./global-s3-assets/ s3://$DIST_OUTPUT_BUCKET-$REGION/$SOLUTION_NAME/$VERSION/ --recursive --acl bucket-owner-full-control
+aws s3 sync ./regional-s3-assets/ s3://$DIST_OUTPUT_BUCKET-$REGION/$SOLUTION_NAME/$VERSION/ --acl bucket-owner-full-control
+aws s3 sync ./global-s3-assets/ s3://$DIST_OUTPUT_BUCKET-$REGION/$SOLUTION_NAME/$VERSION/ --acl bucket-owner-full-control
 ```
 
 ### 6. Launch the CloudFormation template.


### PR DESCRIPTION
I was getting the error `Unknown options: --recursive` when running lines 67 and 68 of the readme with `aws-cli/2.1.15`.
When the `--recursive` option is removed, the command works.

**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->



**Description of changes:**
<!-- Please describe the changes you made -->


**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
