### PR TITLE
Allow rotation transformation without angle argument

### DIFF
--- a/source/image-handler/thumbor-mapper.ts
+++ b/source/image-handler/thumbor-mapper.ts
@@ -343,7 +343,7 @@ export class ThumborMapper {
         break;
       }
       case "rotate": {
-        currentEdits.rotate = Number(filterValue);
+        currentEdits.rotate = filterValue === '' ? undefined : Number(filterValue);
         break;
       }
       case "sharpen": {


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->

Related: github.com/aws-solutions/dynamic-image-transformation-for-amazon-cloudfront/issues/495

**Description of changes:**
<!-- Please describe the changes you made -->

This change enables the `rotate` filter to be used without an angle argument (e.g., `filters:rotate()`). The previous implementation would parse this as `0` and pass it to `sharp.rotate()`.

The new implementation takes advantage of Sharp's behavior when `rotate()` is called without arguments:

1. It automatically determines the rotation angle from the EXIF data
2. It supports mirroring operations when needed
3. It removes the EXIF `Orientation` tag after applying the rotation

This change helps fix issues with images that contain EXIF orientation metadata but are displayed incorrectly in clients (e.g., browsers) that don't support EXIF orientation.

Reference: [Sharp Documentation - rotate](https://sharp.pixelplumbing.com/api-operation#rotate)

**Note**: I have verified that the change works as expected, but additional unit tests may be needed to ensure proper coverage.

**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [x] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
