### PR TITLE
refactor(v8): add missing log retention

### DIFF
--- a/source/constructs/lib/v8/constructs/frontend/csp-updater-construct.ts
+++ b/source/constructs/lib/v8/constructs/frontend/csp-updater-construct.ts
@@ -6,7 +6,7 @@ import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Provider } from "aws-cdk-lib/custom-resources";
 import { Construct } from "constructs";
-import { DITNodejsFunction } from "../common";
+import { DITNodejsFunction, LOG_RETENTION_DAYS } from "../common";
 import { addCfnGuardSuppressRules } from "../../../../utils/utils";
 
 export interface CSPUpdaterConstructProps {
@@ -83,6 +83,7 @@ export class CSPUpdaterConstruct extends Construct {
 
     const provider = new Provider(this, "CSPUpdaterProvider", {
       onEventHandler: cspUpdaterFunction,
+      logRetention: LOG_RETENTION_DAYS,
     });
 
     new CustomResource(this, "CSPUpdaterCustomResource", {

--- a/source/constructs/lib/v8/stacks/management-stack.ts
+++ b/source/constructs/lib/v8/stacks/management-stack.ts
@@ -10,6 +10,7 @@ import { AuthConstruct, WebDistributionConstruct } from "../constructs/frontend"
 import { CSPUpdaterConstruct } from "../constructs/frontend/csp-updater-construct";
 import { MetricsConstruct } from "../constructs/metrics";
 import { ImageProcessingStack } from "./image-processing-stack";
+import { LOG_RETENTION_DAYS } from "../constructs/common";
 
 export interface ManagementStackProps extends StackProps {
   solutionId: string;
@@ -98,6 +99,7 @@ export class ManagementStack extends Stack {
       ],
       destinationBucket: webConstruct.bucket,
       prune: true,
+      logRetention: LOG_RETENTION_DAYS,
     });
 
 

--- a/source/constructs/lib/v8/test/snapshot/__snapshots__/management-stack.test.ts.snap
+++ b/source/constructs/lib/v8/test/snapshot/__snapshots__/management-stack.test.ts.snap
@@ -707,6 +707,29 @@ Temporary Password: <strong>{####}</strong>
       },
       "Type": "AWS::Lambda::Function",
     },
+    "CSPUpdaterCSPUpdaterProviderframeworkonEventLogRetention609BA59B": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "CSPUpdaterCSPUpdaterProviderframeworkonEventE7D5E323",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 3653,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
     "CSPUpdaterCSPUpdaterProviderframeworkonEventServiceRole9DF2EE66": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -914,6 +937,29 @@ Temporary Password: <strong>{####}</strong>
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CLogRetention1948627D": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 3653,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
     },
     "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
       "Properties": {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix missing log retention configuration for CDK-managed Lambda functions in v8 stack.
<img width="1390" height="386" alt="Screenshot 2025-11-25 at 3 43 58 PM" src="https://github.com/user-attachments/assets/37e9e4e3-1c08-4b04-8063-500dae673852" />

**Changes**
- Added `logRetention` property to BucketDeployment construct (`AdminUIDeployment`)
- Added `logRetention` property to Provider construct (`CSPUpdaterProvider`)

**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
