### PR TITLE
fix: stripExif now properly removes all EXIF data

### DIFF
--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -45,12 +45,8 @@ export class ImageHandler {
       let image = sharp(originalImage, options).keepIccProfile().keepMetadata();
 
       if (edits?.stripExif === true) {
-        // Removes all EXIF by inserting minimal EXIF tag. Leaves ICC untouched.
-        image.keepIccProfile().withExif({
-          IFD0: {
-            Software: 'Dynamic Image Transformation for Amazon CloudFront'
-          }
-        });
+        // Removes all EXIF by setting empty EXIF data. Leaves ICC untouched.
+        image.keepIccProfile().withExif({});
         delete edits.stripExif;
       }
 


### PR DESCRIPTION
Fixes #636

Uses `withExif({})` with an empty object to properly strip all EXIF metadata instead of just adding a Software key while keeping existing EXIF data.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*