### PR TITLE
fix: correct sharp cross-platform bundling for image handler Lambda

### DIFF
--- a/source/constructs/lib/back-end/back-end-construct.ts
+++ b/source/constructs/lib/back-end/back-end-construct.ts
@@ -133,9 +133,13 @@ export class BackEnd extends Construct {
             return [];
           },
           afterBundling(inputDir: string, outputDir: string): string[] {
+            // Must be a single command: each array element runs in its own shell, so `cd`
+            // cannot be split from the install or it won't apply. Remove the host-platform
+            // sharp binaries and the lock file (the lock pins darwin deps and would override
+            // the --os/--cpu flags), then force-install the linux-x64 build. --include=optional
+            // is required so npm 11 actually pulls the platform-specific @img/* package.
             return [
-              `cd ${outputDir}`,
-              "rm -rf node_modules/sharp && npm install --cpu=x64 --os=linux --libc=glibc sharp", // npm 10.4.0+ --libc=glibc is needed for the platform-specific deps to be installed when cross-compiling sharp from mac to linux
+              `cd ${outputDir} && rm -rf node_modules/sharp node_modules/@img package-lock.json && npm install --include=optional --cpu=x64 --os=linux --libc=glibc sharp`,
             ];
           },
         },


### PR DESCRIPTION
Fixes #646

## Summary

The `afterBundling` command hook for the image handler Lambda produced a macOS (darwin-arm64) sharp binary that fails to load on the linux-x64 Lambda runtime, causing `Could not load the "sharp" module` and HTTP 502 for every request when synthesized on macOS.

This PR fixes three compounding issues in a single hook command:

- **`cd` was split from the install.** The hook returned two array elements; CDK runs each in its own shell, so `cd ${outputDir}` never applied to the `npm install`. They are now chained into one command.
- **`@img/` binaries were not removed.** sharp 0.33+ ships native binaries under `@img/sharp-<platform>`, so removing only `node_modules/sharp` left the host darwin binary. `node_modules/@img` is now removed too.
- **The lock file pinned darwin deps.** The copied `package-lock.json` overrode the `--os/--cpu` flags. It is now removed, and `--include=optional` is added so npm 11 actually pulls the linux-x64 `@img` package.

## 修复说明

`afterBundling` 钩子打进 Lambda 的是 macOS 版 sharp 二进制，在 linux-x64 运行时加载失败，导致每个请求 502。本 PR 在单条钩子命令里修复三个叠加问题：`cd` 与 install 合并为一条命令；额外删除 `@img/`（sharp 0.33+ 的原生二进制目录）；删除锁定 darwin 的 `package-lock.json` 并加 `--include=optional` 以适配 npm 11。

## Test plan

- [x] `cdk synth` on macOS now produces `@img/sharp-linux-x64` (verified the staged asset).
- [x] Deployed `v7-Stack` to us-east-1; image handler Lambda loads sharp successfully.
- [x] Verified via CloudFront: original passthrough, resize (300x200), and grayscale + WebP conversion all return HTTP 200.